### PR TITLE
Vle 825 remove unnecessary arguments from freight scenario run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "valma-ui",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "valma-ui",
-      "version": "1.0.13",
+      "version": "1.0.14",
       "license": "EUPL-1.2",
       "dependencies": {
         "@electron/remote": "^2.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valma-ui",
   "productName": "VALMA",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "private": true,
   "description": "VALMA Model System UI",
   "main": "src/main/index.js",

--- a/src/background/lem_entrypoint_python_shell.js
+++ b/src/background/lem_entrypoint_python_shell.js
@@ -34,6 +34,7 @@ module.exports = {
           .concat(allRunParameters.map(p => p.separate_emme_scenarios).every(Boolean) ? ["--separate-emme-scenarios"] : [])
           .concat(["--freight-matrix-paths"]).concat(allRunParameters.map(p => p.freight_matrix_path ? p.freight_matrix_path: 'none'))
           .concat(["--submodel"]).concat(allRunParameters.map(p => p.submodel))
+          .concat(["--model-types"]).concat(allRunParameters.map(p => p.scenarioType))
       });
 
     // Attach runtime handlers (stdout/stderr, process errors)
@@ -63,7 +64,7 @@ module.exports = {
     }
 
     let longDistDemandForecast = getLongDistDemandForecast(runParameters.long_dist_demand_forecast,  runParameters.long_dist_demand_forecast_path);
-    // Start lem-model-system's lem.py in shell with EMME's python interpreter
+    // Start lem-model-system's valma_travel.py in shell with EMME's python interpreter
     worker = new ps.PythonShell(
       `${runParameters.helmet_scripts_path}/valma_travel.py`,
       {
@@ -119,7 +120,7 @@ module.exports = {
       return;
     }
 
-    // Start lem-model-system's lem.py in shell with EMME's python interpreter
+    // Start lem-model-system's valma_freight.py in shell with EMME's python interpreter
     worker = new ps.PythonShell(
       `${runParameters.helmet_scripts_path}/valma_freight.py`,
       {
@@ -133,15 +134,12 @@ module.exports = {
           "--results-path", runParameters.results_data_folder_path,
           "--emme-path", runParameters.emme_project_path,
           "--first-scenario-id", runParameters.first_scenario_id,
-          "--baseline-data-path", runParameters.base_data_folder_path,
           "--cost-data-path", runParameters.costDataPath,
           "--forecast-data-path", runParameters.forecast_data_path,
           "--trade-demand-data-path", runParameters.tradeDemandDataPath,
           "--first-matrix-id", (runParameters.first_matrix_id == null ? "100" : runParameters.first_matrix_id),
-          "--iterations", 0,
         ]
           .concat(runParameters.delete_strategy_files == true | runParameters.delete_strategy_files == null ? ["--del-strat-files"] : [])
-          .concat(runParameters.submodel ? ["--submodel", runParameters.submodel] : [])
       });
 
     // Attach runtime handlers (stdout/stderr, process errors)

--- a/src/renderer/components/Project/Runtime/ScenarioTable/ScenarioTableRow.jsx
+++ b/src/renderer/components/Project/Runtime/ScenarioTable/ScenarioTableRow.jsx
@@ -152,7 +152,7 @@ const ScenarioTableRow = ({
           duplicateSubScenario={duplicateSubScenario}
           deleteSubScenario={deleteSubScenario}
           modifySubScenario={modifySubScenario}
-          parentScenarioIsRunOrSelectedForRunning={(resultsExist && scenarioLogExists && scenarioData.run_success) || scenarioIDsToRun.includes(scenarioData.id)}
+          parentScenarioIsRunOrSelectedForRunning={(resultsExist && scenarioLogExists && (scenarioData.run_success == true && scenarioData.last_run != "")) || scenarioIDsToRun.includes(scenarioData.id)}
           parentScenarioResultsPath={scenarioProjectFolder}/>
       ))}
     </Fragment>

--- a/src/renderer/components/Project/VlemProject.jsx
+++ b/src/renderer/components/Project/VlemProject.jsx
@@ -40,7 +40,7 @@ const VlemProject = ({
     if (scenarioIDsToRun.includes(scenario.id)) {
       // If scenario exists in scenarios to run, remove it
       let newScenarioIds = scenarioIDsToRun.filter((id) => id !== scenario.id);
-      if (scenario.subScenarios && (!scenario.run_success || scenario.run_success == false) && !scenario.last_run) {
+      if (scenario.subScenarios && (!scenario.run_success || scenario.run_success == false || scenario.last_run == "")) {
         scenario.subScenarios.forEach(subScenario => newScenarioIds = newScenarioIds.filter((id) => id !== subScenario.id));
       }
       setScenarioIDsToRun(newScenarioIds);
@@ -240,6 +240,7 @@ const VlemProject = ({
     //Change ID and rename the scenario to avoid conflicts.
     duplicatedScenario.id = uuidv4();
     duplicatedScenario.name += `(${duplicatedScenario.id.split('-')[0]})`;
+    duplicatedScenario.subScenarios = [];
     const tempScenarios = scenarios.concat(duplicatedScenario);
     setScenarios(tempScenarios);
     resolveScenarioNames(tempScenarios);
@@ -412,7 +413,6 @@ const VlemProject = ({
   }
 
   function resolveRunnableScenarios(scenarioIDsToRun, scenarios) {
-
     if (!scenarioIDsToRun || scenarioIDsToRun.length == 0 || !scenarios || scenarios.length == 0) {
       return [];
     }
@@ -443,6 +443,7 @@ const VlemProject = ({
         })
       }
     });
+
     const sortedRunnableScenarios = runnableScenarios.sort((a, b) => a.runIndex - b.runIndex);
     return sortedRunnableScenarios;
   }


### PR DESCRIPTION
- Remove arguments from valma_freight.py call
- Add --model-types to validate_inputfiles.py
- Fixes cloning scenario in the way sub scenarios will not be cloned
    (the get mixed id and parent reference data when cloned)
- Fixes deselecting subscenario if parent is deselected and not run